### PR TITLE
Remove left over console.log command

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,6 @@
 import * as vscode from 'vscode';
 
 export function activate(context: vscode.ExtensionContext) {
-
     vscode.workspace.onDidChangeTextDocument(event => {
         insertAutoCloseTag(event);
     });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,6 @@
 import * as vscode from 'vscode';
 
 export function activate(context: vscode.ExtensionContext) {
-    console.log('Congratulations, your extension "auto-close-tag" is now active!');
 
     vscode.workspace.onDidChangeTextDocument(event => {
         insertAutoCloseTag(event);


### PR DESCRIPTION
The log message is an example from the initial extension template. If one develops another extension, it prints right into the open debug console. Additionally, although in this case not always visible, it prints into the console of the developer tools on every instance load.

![screen shot 2016-10-13 at 10 12 50](https://cloud.githubusercontent.com/assets/7542/19341754/1935b8fa-912f-11e6-84ee-6c4ca2bc5a1a.png)
