### PR TITLE
Remove special category Keymaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     },
     "categories": [
         "Other",
-        "Languages",
-        "Keymaps"
+        "Languages"
     ],
     "keywords": [
         "AutoComplete",


### PR DESCRIPTION
We are reserving the Keymaps category for large reassignments of key-mappings to emulate other editors like Vim, Atom, Sublime. We will add documentation to our website, submitting this PR for now. /cc @ waderyan