### PR TITLE
Add default support for markdown react

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
                         "typescriptreact",
                         "plaintext",
                         "markdown",
+                        "mdx",
                         "vue",
                         "liquid",
                         "erb",


### PR DESCRIPTION
MDX is a popular markdown format that lets you seamlessly use react/jsx syntax in your markdown documents. Auto-closing is as just as helpful here as it is for javascriptreact/typescriptreact. Default support for markdown react would be great.

https://github.com/mdx-js/mdx