### PR TITLE
Update EEx language name in default settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
                         "erb",
                         "lang-cfml",
                         "cfml",
-                        "HTML (Eex)"
+                        "HTML (EEx)"
                     ],
                     "description": "Set the languages that the extension will be activated.  e.g. [\"html\",\"xml\",\"php\"]. Use [\"*\"] to activate for all languages.",
                     "scope": "resource"


### PR DESCRIPTION
VS Code marks Embedded Elixir files with HTML as `HTML (EEx)`, but the default options has the entry `HTML (Eex)` which does not work (casing is off). This PR fixes this issue.