### PR TITLE
Self-close brackets with a space.

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,6 +129,12 @@
                     "description": "Whether to close self-closing tag automatically",
                     "scope": "resource"
                 },
+                "auto-close-tag.selfClosingSpace": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Add a space before self-closing brackets",
+                    "scope": "resource"
+                },
                 "auto-close-tag.fullMode": {
                     "type": "boolean",
                     "default": false,


### PR DESCRIPTION
This pull request adds an option to add a space before a self-closing tag. When enabled...

> `<meta` + <kbd>/</kbd> = `<meta />`

Naturally, the no-space behavior remains the default.