### PR TITLE
Support self-closing tags with spaces.

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,6 +129,12 @@
                     "description": "Whether to close self-closing tag automatically",
                     "scope": "resource"
                 },
+                "auto-close-tag.insertSpaceBeforeSelfClosingTag": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Insert a space before the forward slash in a self-closing tag.",
+                    "scope": "resource"
+                },
                 "auto-close-tag.fullMode": {
                     "type": "boolean",
                     "default": false,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -92,6 +92,10 @@ function insertAutoCloseTag(event: vscode.TextDocumentChangeEvent): void {
             } else {
                 if (textLine.text.length <= selection.start.character + 1 || textLine.text[selection.start.character + 1] !== '>') { // if not typing "/" just before ">", add the ">" after "/"
                     editor.edit((editBuilder) => {
+                        if (config.get<boolean>("insertSpaceBeforeSelfClosingTag")) {
+                            const spacePosition = originalPosition.translate(0, -1);
+                            editBuilder.insert(spacePosition, " ");
+                        }
                         editBuilder.insert(originalPosition, ">");
                     })
                 }
@@ -177,4 +181,4 @@ function moveSelectionRight(selection: vscode.Selection, shift: number): vscode.
 
 function occurrenceCount(source: string, find: string): number {
     return source.split(find).length - 1;
-} 
+}


### PR DESCRIPTION
Adds optional support for inserting a space between a self-closing tag’s element name. With the configuration flag on, typing <kbd><br</kbd> <kbd>/</kbd> will close the tag as `<br />`. This is the preferred style of many popular React style guides. (And for my own personal self.)