### PR TITLE
Exclude images from extension package

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -7,3 +7,5 @@ src/**
 .gitignore
 tsconfig.json
 vsc-extension-quickstart.md
+images
+!images/logo.png


### PR DESCRIPTION
First of all, thanks for this awesome extension! I noticed some large images are not excluded in the extension package, hence this pull request.

With the images excluded, the package size goes from 773.63KB down to merely 19.71KB! It does not break the links as VSCode rewrites assets in README to use GitHub links.