### PR TITLE
feat: activate on glimmer js/ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Automatically add HTML/XML close tag, same as Visual Studio IDE or Sublime Text 
 
 ## Note
 
-From VS Code 1.16, it has [built-in close tag support](https://code.visualstudio.com/updates/v1_16#_html-close-tags) for HTML, Handlebars and Razor files. This extension is enabled for other languages like XML, PHP, Vue, JavaScript, TypeScript, JSX, TSX and so on. It is configurable.
+From VS Code 1.16, it has [built-in close tag support](https://code.visualstudio.com/updates/v1_16#_html-close-tags) for HTML, Handlebars and Razor files. This extension is enabled for other languages like XML, PHP, Vue, JavaScript, TypeScript, JSX, TSX, GJS, GTS, and so on. It is configurable.
 
 ## Features
 
@@ -76,6 +76,8 @@ Add entry into `auto-close-tag.activationOnLanguage` to set the languages that t
         "php",
         "blade",
         "ejs",
+        "glimmer-js",
+        "glimmer-ts",
         "jinja",
         "javascript",
         "javascriptreact",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,8 @@
                         "php",
                         "blade",
                         "ejs",
+                        "glimmer-js",
+                        "glimmer-ts",
                         "jinja",
                         "javascript",
                         "javascriptreact",


### PR DESCRIPTION
Adds support for [Glimmer.js](https://glimmerjs.com/) which is the [component authoring format](https://github.com/ember-template-imports/ember-template-imports) of the [Polaris Edition of Ember.js](https://emberjs.com/editions/polaris/).

RFC: https://rfcs.emberjs.com/id/0779-first-class-component-templates/